### PR TITLE
Simplify logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,9 @@ if err != nil {
 // Set lowest log level to info
 log.SetLevel(simplog.Info)
 
-// fmt.Print style
-log.Info("You're awesome!\n")
-
-// fmt.Println style
-log.Warningln("Coffee is almost empty.")
+// Log messages with different levels of importance.
+log.Info("You're awesome!")
+log.Warning("Coffee is almost empty.")
 
 // The following message will not be logged because 'Info' was set
 // as the lowest allowed log level.
@@ -65,8 +63,8 @@ log.Warningln("Coffee is almost empty.")
 //  - Error
 //  - Fatal
 // 
-// // fmt.Printf style 
-log.Debugf("%d should be equal to %d.\n", aNumber, anotherNumber)
+// Log messages support fmt.Printf style by default.
+log.Debug("%d should be equal to %d.", aNumber, anotherNumber)
 
 ```
 

--- a/simplog.go
+++ b/simplog.go
@@ -85,85 +85,39 @@ func (s *Simplog) SetFlags(flag int) {
 	s.loggr.SetFlags(flag)
 }
 
+// Write log message to outputs.
 func (s *Simplog) write(level Level, levelTag, msg string) {
 	if s.level >= level {
+		if !strings.HasSuffix(msg, "\n") {
+			msg += "\n"
+		}
 		writeLock.Lock()
 		defer writeLock.Unlock()
 		_ = s.loggr.Output(3, levelTag+" "+msg)
 	}
 }
 
-// Debug logs a debug message in style of fmt.Print
-func (s *Simplog) Debug(v ...interface{}) {
-	s.write(Debug, debugTag, fmt.Sprint(v...))
-}
-
-// Debugln logs a debug message in style of fmt.Println
-func (s *Simplog) Debugln(v ...interface{}) {
-	s.write(Debug, debugTag, fmt.Sprintln(v...))
-}
-
-// Debugf logs a debug message in style of fmt.Printf
-func (s *Simplog) Debugf(format string, v ...interface{}) {
+// Debug logs a debug message in style of fmt.Printf. New line will be automatically appended.
+func (s *Simplog) Debug(format string, v ...interface{}) {
 	s.write(Debug, debugTag, fmt.Sprintf(format, v...))
 }
 
-// Info logs a info message in style of fmt.Print
-func (s *Simplog) Info(v ...interface{}) {
-	s.write(Info, infoTag, fmt.Sprint(v...))
-}
-
-// Infoln logs a info message in style of fmt.Println
-func (s *Simplog) Infoln(v ...interface{}) {
-	s.write(Info, infoTag, fmt.Sprintln(v...))
-}
-
-// Infof logs a info message in style of fmt.Printf
-func (s *Simplog) Infof(format string, v ...interface{}) {
+// Info logs a info message in style of fmt.Printf. New line will be automatically appended.
+func (s *Simplog) Info(format string, v ...interface{}) {
 	s.write(Info, infoTag, fmt.Sprintf(format, v...))
 }
 
-// Warning logs a warning message in style of fmt.Print
-func (s *Simplog) Warning(v ...interface{}) {
-	s.write(Warning, warningTag, fmt.Sprint(v...))
-}
-
-// Warningln logs a warning message in style of fmt.Println
-func (s *Simplog) Warningln(v ...interface{}) {
-	s.write(Warning, warningTag, fmt.Sprintln(v...))
-}
-
-// Warningf logs a warning message in style of fmt.Printf
-func (s *Simplog) Warningf(format string, v ...interface{}) {
+// Warning logs a warning message in style of fmt.Printf. New line will be automatically appended.
+func (s *Simplog) Warning(format string, v ...interface{}) {
 	s.write(Warning, warningTag, fmt.Sprintf(format, v...))
 }
 
-// Error logs a error message in style of fmt.Print
-func (s *Simplog) Error(v ...interface{}) {
-	s.write(Error, errorTag, fmt.Sprint(v...))
-}
-
-// Errorln logs a error message in style of fmt.Println
-func (s *Simplog) Errorln(v ...interface{}) {
-	s.write(Error, errorTag, fmt.Sprintln(v...))
-}
-
-// Errorf logs a error message in style of fmt.Printf
-func (s *Simplog) Errorf(format string, v ...interface{}) {
+// Error logs a error message in style of fmt.Printf. New line will be automatically appended.
+func (s *Simplog) Error(format string, v ...interface{}) {
 	s.write(Error, errorTag, fmt.Sprintf(format, v...))
 }
 
-// Fatal logs a fatal message in style of fmt.Print
-func (s *Simplog) Fatal(v ...interface{}) {
-	s.write(Fatal, fatalTag, fmt.Sprint(v...))
-}
-
-// Fatalln logs a fatal message in style of fmt.Println
-func (s *Simplog) Fatalln(v ...interface{}) {
-	s.write(Fatal, fatalTag, fmt.Sprintln(v...))
-}
-
-// Fatalf logs a fatal message in style of fmt.Printf
-func (s *Simplog) Fatalf(format string, v ...interface{}) {
+// Fatal logs a fatal message in style of fmt.Printf. New line will be automatically appended.
+func (s *Simplog) Fatal(format string, v ...interface{}) {
 	s.write(Fatal, fatalTag, fmt.Sprintf(format, v...))
 }


### PR DESCRIPTION
### Summary

Simplify writer functions. Removed all the varieties. Now there is only one writer function for every log level.
